### PR TITLE
Fix File upload Case Sensitivity

### DIFF
--- a/core/Piranha/Extend/MediaManager.cs
+++ b/core/Piranha/Extend/MediaManager.cs
@@ -56,7 +56,7 @@ namespace Piranha.Extend
             /// <param name="extension">The file extension</param>
             /// <returns>If the extension exists</returns>
             public bool ContainsExtension(string extension) {
-                return this.Any(t => t.Extension == extension);
+                return this.Any(t => t.Extension.Equals(extension, System.StringComparison.OrdinalIgnoreCase));
             }
         }
 


### PR DESCRIPTION
When you uplaod a file with an upercase extension the extension check
will fill. This fix resolves that.